### PR TITLE
make connection_timeout param accept non-integer values

### DIFF
--- a/keepalived/check/check_api.c
+++ b/keepalived/check/check_api.c
@@ -67,7 +67,7 @@ dump_conn_opts (conn_opts_t *conn)
 	if (conn->fwmark != 0)
 		log_message(LOG_INFO, "   Connection mark = %u", conn->fwmark);
 #endif
-	log_message(LOG_INFO, "   Connection timeout = %d", conn->connection_to/TIMER_HZ);
+	log_message(LOG_INFO, "   Connection timeout = %f", ((double) conn->connection_to)/TIMER_HZ);
 }
 
 /* Queue a checker into the checkers_queue */
@@ -172,7 +172,7 @@ static void
 co_timeout_handler(vector_t *strvec)
 {
 	conn_opts_t *co = CHECKER_GET_CO();
-	co->connection_to = CHECKER_VALUE_INT(strvec) * TIMER_HZ;
+	co->connection_to = CHECKER_VALUE_TIMER(strvec);
 
 	/* do not allow 0 timeout */
 	if (! co->connection_to)

--- a/keepalived/include/check_api.h
+++ b/keepalived/include/check_api.h
@@ -63,6 +63,8 @@ extern list checkers_queue;
 #define CHECKER_GET() (CHECKER_DATA(CHECKER_GET_CURRENT()))
 #define CHECKER_GET_CO() (((checker_t *)CHECKER_GET_CURRENT())->co)
 #define CHECKER_VALUE_INT(X) (atoi(vector_slot(X,1)))
+#define CHECKER_VALUE_DOUBLE(X) (atof(vector_slot(X,1)))
+#define CHECKER_VALUE_TIMER(X) (CHECKER_VALUE_DOUBLE(X) * TIMER_HZ)
 #define CHECKER_VALUE_STRING(X) (set_value(X))
 #define CHECKER_VHOST(C) (VHOST((C)->vs))
 #define CHECKER_ENABLED(C) ((C)->enabled)

--- a/keepalived/include/check_api.h
+++ b/keepalived/include/check_api.h
@@ -31,7 +31,7 @@
 typedef struct _conn_opts {
 	struct sockaddr_storage		dst;
 	struct sockaddr_storage		bindto;
-	unsigned int			connection_to; /* connection time-out */
+	unsigned long			connection_to; /* connection time-out */
 #ifdef _WITH_SO_MARK_
 	unsigned int			fwmark; /* to mark packets going out of the socket using SO_MARK */
 #endif


### PR DESCRIPTION
- make connection_timeout param accept non-integer values
- convert connection_to to long since it is used in timer code
