### PR TITLE
Fix signal handler hangup after first reload

### DIFF
--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -172,12 +172,26 @@ sigend_check(void *v, int sig)
 
 /* CHECK Child signal handling */
 void
-check_signal_init(void)
+check_signal_enable(void)
 {
-	signal_handler_init();
 	signal_set(SIGHUP, sighup_check, NULL);
 	signal_set(SIGINT, sigend_check, NULL);
 	signal_set(SIGTERM, sigend_check, NULL);
+}
+
+void
+check_signal_disable(void)
+{
+	signal_ignore(SIGHUP);
+	signal_ignore(SIGINT);
+	signal_ignore(SIGTERM);
+}
+
+void
+check_signal_init(void)
+{
+	signal_handler_init();
+	check_signal_enable();
 	signal_ignore(SIGPIPE);
 }
 
@@ -191,15 +205,13 @@ reload_check_thread(thread_t * thread)
 	log_message(LOG_INFO, "Got SIGHUP, reloading checker configuration");
 
 	/* Signals handling */
-	signal_reset();
-	signal_handler_destroy();
+	check_signal_disable();
 
 	/* Destroy master thread */
 #ifdef _WITH_VRRP_
 	kernel_netlink_close();
 #endif
-	thread_destroy_master(master);
-	master = thread_make_master();
+	thread_destroy_queues(master);
 	free_global_data(global_data);
 	free_checkers_queue();
 #ifdef _WITH_VRRP_
@@ -214,7 +226,7 @@ reload_check_thread(thread_t * thread)
 
 	/* Reload the conf */
 	mem_allocated = 0;
-	check_signal_init();
+	check_signal_enable();
 	signal_set(SIGCHLD, thread_child_handler, master);
 	start_check();
 

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -207,14 +207,30 @@ sigend_vrrp(void *v, int sig)
 
 /* VRRP Child signal handling */
 void
-vrrp_signal_init(void)
+vrrp_signal_enable(void)
 {
-	signal_handler_init();
 	signal_set(SIGHUP, sighup_vrrp, NULL);
 	signal_set(SIGINT, sigend_vrrp, NULL);
 	signal_set(SIGTERM, sigend_vrrp, NULL);
 	signal_set(SIGUSR1, sigusr1_vrrp, NULL);
 	signal_set(SIGUSR2, sigusr2_vrrp, NULL);
+}
+
+void
+vrrp_signal_disable(void)
+{
+	signal_ignore(SIGHUP);
+	signal_ignore(SIGINT);
+	signal_ignore(SIGTERM);
+	signal_ignore(SIGUSR1);
+	signal_ignore(SIGUSR2);
+}
+
+void
+vrrp_signal_init(void)
+{
+	signal_handler_init();
+	vrrp_signal_enable();
 	signal_ignore(SIGPIPE);
 }
 
@@ -226,14 +242,12 @@ reload_vrrp_thread(thread_t * thread)
 	SET_RELOAD;
 
 	/* Signal handling */
-	signal_reset();
-	signal_handler_destroy();
+	vrrp_signal_disable();
 
 	/* Destroy master thread */
 	vrrp_dispatcher_release(vrrp_data);
 	kernel_netlink_close();
-	thread_destroy_master(master);
-	master = thread_make_master();
+	thread_destroy_queues(master);
 	free_global_data(global_data);
 	free_interface_queue();
 	free_vrrp_buffer();
@@ -253,7 +267,7 @@ reload_vrrp_thread(thread_t * thread)
 
 	/* Reload the conf */
 	mem_allocated = 0;
-	vrrp_signal_init();
+	vrrp_signal_enable();
 	signal_set(SIGCHLD, thread_child_handler, master);
 	start_vrrp();
 

--- a/lib/scheduler.h
+++ b/lib/scheduler.h
@@ -113,6 +113,7 @@ extern thread_master_t *master;
 extern thread_master_t *thread_make_master(void);
 extern thread_t *thread_add_terminate_event(thread_master_t *);
 extern void thread_destroy_master(thread_master_t *);
+extern void thread_destroy_queues(thread_master_t *);
 extern thread_t *thread_add_read(thread_master_t *, int (*func) (thread_t *), void *, int, long);
 extern thread_t *thread_add_write(thread_master_t *, int (*func) (thread_t *), void *, int, long);
 extern thread_t *thread_add_timer(thread_master_t *, int (*func) (thread_t *), void *, long);


### PR DESCRIPTION
Reload closes pipe fds which was added at lauch_scheduler(), which results in signal handlers not working after first SIGHUP
Fix reload code since there is no need to completely destroy thread_master instance
Disable signals so we would not be caught mid-reconfiguring
VRRP reload code fixed accordingly
